### PR TITLE
WIP: Add proxy endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ To override the default settings:
 * `GET /env/<ENV_VAR>`
     * _returns_: the value of `env_var` or `404` if the environment variable does not exist.
 * `GET /aws/<METADATA_ENDPOINT>`
-<<<<<<< HEAD
     * _returns_: the value of the AWS `metadata_endpoint`, `501` if `infrabin` can not open the AWS metadata URL, or `404` if the metadata endpoint does not exist. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-data-categories for the available endpoints.
 * `GET /status`
     * _returns_: the JSON `{"dns":{"status": "ok"}, "egress": {"status": "ok"}}` if `infrabin` can resolve `google.com` using Google's DNS and can connect to `https://www.google.com`. If a test fails, `infrabin` returns `"status": "error"` and the `reason`.
@@ -44,8 +43,8 @@ To override the default settings:
 * `GET /replay/<URL>`
     * _returns_: a JSON with the requested url.
 * `POST /proxy`
-    * _parameters_: a JSON with a list of url (mandatory), method (optional) and payload (optional) to proxy.
-    * _returns_: `404` if the request if malformed or a JSON with the response of every url. If successful, the response contains `status: ok`, the `status_code` and the `headers`. If unsuccessful, the response contains `status: error` and the `reason`.
+    * _payload_: a JSON with a list of `url` (mandatory), `method` (optional) and `payload` (optional) to proxy.
+    * _returns_: `400` if the request if malformed or a JSON with the a response for every request. If successful, the response contains `status: ok`, the `status_code` and the `headers`. If unsuccessful, the response contains `status: error` and the `reason`.
 
 ## Examples
 * `POST /status`

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To override the default settings:
 * `GET /env/<ENV_VAR>`
     * _returns_: the value of `env_var` or `404` if the environment variable does not exist.
 * `GET /aws/<METADATA_ENDPOINT>`
+<<<<<<< HEAD
     * _returns_: the value of the AWS `metadata_endpoint`, `501` if `infrabin` can not open the AWS metadata URL, or `404` if the metadata endpoint does not exist. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-data-categories for the available endpoints.
 * `GET /status`
     * _returns_: the JSON `{"dns":{"status": "ok"}, "egress": {"status": "ok"}}` if `infrabin` can resolve `google.com` using Google's DNS and can connect to `https://www.google.com`. If a test fails, `infrabin` returns `"status": "error"` and the `reason`.
@@ -42,7 +43,9 @@ To override the default settings:
     * _returns_: the JSON `{"message": "this is gzip compressed"}` gzip compressed.
 * `GET /replay/<URL>`
     * _returns_: a JSON with the requested url.
-
+* `POST /proxy`
+    * _parameters_: a JSON with a list of url (mandatory), method (optional) and payload (optional) to proxy.
+    * _returns_: `404` if the request if malformed or a JSON with the response of every url. If successful, the response contains `status: ok`, the `status_code` and the `headers`. If unsuccessful, the response contains `status: error` and the `reason`.
 
 ## Examples
 * `POST /status`
@@ -62,6 +65,46 @@ $ curl -d '{"nameservers":["208.67.222.222"],"query":"facebook.com","egress_url"
 $ curl localhost:8080/replay/the/meaning/of/life/42
 {
   "replay": "the/meaning/of/life/42"
+}
+```
+* `POST /proxy`
+```
+$ curl -d '[{"url":"https://www.google.com"},{"url":"http://httpbin.org/post","method":"POST","payload":{"key":"42"}}]' -H "Content-Type: application/json" -X POST localhost:8080/proxy
+{
+  "http://httpbin.org/post": {
+    "headers": {
+      "Access-Control-Allow-Credentials": "true",
+      "Access-Control-Allow-Origin": "*",
+      "Connection": "keep-alive",
+      "Content-Length": "435",
+      "Content-Type": "application/json",
+      "Date": "Sat, 19 Aug 2017 23:39:35 GMT",
+      "Server": "meinheld/0.6.1",
+      "Via": "1.1 vegur",
+      "X-Powered-By": "Flask",
+      "X-Processed-Time": "0.00157999992371"
+    },
+    "status": "ok",
+    "status_code": 200
+  },
+  "https://www.google.com": {
+    "headers": {
+      "Alt-Svc": "quic=\":443\"; ma=2592000; v=\"39,38,37,35\"",
+      "Cache-Control": "private, max-age=0",
+      "Content-Encoding": "gzip",
+      "Content-Type": "text/html; charset=ISO-8859-1",
+      "Date": "Sat, 19 Aug 2017 23:39:35 GMT",
+      "Expires": "-1",
+      "P3P": "CP=\"This is not a P3P policy! See https://www.google.com/support/accounts/answer/151657?hl=en for more info.\"",
+      "Server": "gws",
+      "Set-Cookie": "NID=110=gR5VUAdefT9VbTSdOHEaiP-_ryClfvAV3ovON-uOh7d59L8YsQjkQsbDwSNMwEl0JOj-7aXIQnbceL5WGZGnmbz9GFWFHsHPqRsCPaquyHIsboWMNkzhVr4Te2E6-D94; expires=Sun, 18-Feb-2018 23:39:35 GMT; path=/; domain=.google.co.uk; HttpOnly",
+      "Transfer-Encoding": "chunked",
+      "X-Frame-Options": "SAMEORIGIN",
+      "X-XSS-Protection": "1; mode=block"
+    },
+    "status": "ok",
+    "status_code": 200
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # Infrabin
 **Warning: `infrabin` exposes sensitive endpoints and should NEVER be used on the public Internet.**
 
-`infrabin` can be used to simulate blue/green deployments, to test routing and failover and as a general swiss-knife for your infrastructure.
+`infrabin` is an HTTP server that exposes a set of JSON endpoints. It can be used to simulate blue/green deployments, to test routing and failover or as a general swiss-knife for your infrastructure.
 
 # Usage
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-click==6.7
-Flask==0.12.2
-gunicorn==19.7.1
-itsdangerous==0.24
-Jinja2==2.9.6
-MarkupSafe==1.0
-Werkzeug==0.12.2

--- a/src/infrabin/app.py
+++ b/src/infrabin/app.py
@@ -87,7 +87,7 @@ def env(env_var):
 @app.route("/aws/<metadata_categories>")
 def aws(metadata_categories):
     try:
-        r = requests.get(AWS_METADATA_ENDPOINT + metadata_categories, timeout=1)
+        r = requests.get(AWS_METADATA_ENDPOINT + metadata_categories, timeout=3)
     except requests.exceptions.ConnectionError:
         return jsonify({"message": "aws metadata endpoint not available"}), 501
     if r.status_code == 404:
@@ -161,7 +161,7 @@ def proxy():
         url = e.get("url", None)
         if url:
             try:
-                r = requests.request(method=method, url=url, data=payload, timeout=1)
+                r = requests.request(method=method, url=url, data=payload, timeout=5)
                 response[url] = {
                     "status": "ok",
                     "status_code": r.status_code,

--- a/src/infrabin/app.py
+++ b/src/infrabin/app.py
@@ -161,7 +161,7 @@ def proxy():
         url = e.get("url", None)
         if url:
             try:
-                r = requests.request(method=method, url=url, data=payload, timeout=5)
+                r = requests.request(method=method.uppercase, url=url, data=payload, timeout=5)
                 response[url] = {
                     "status": "ok",
                     "status_code": r.status_code,

--- a/src/infrabin/app.py
+++ b/src/infrabin/app.py
@@ -161,7 +161,7 @@ def proxy():
         url = e.get("url", None)
         if url:
             try:
-                r = requests.request(method=method.uppercase, url=url, data=payload, timeout=5)
+                r = requests.request(method=method.upper(), url=url, data=payload, timeout=5)
                 response[url] = {
                     "status": "ok",
                     "status_code": r.status_code,


### PR DESCRIPTION
Add a proxy endpoint to use `infrabin` to make another request to a list of urls. This is useful to test intra-pod communication in k8s.

The endpoint accepts a JSON with a list of url, method (optional) and payload (optional) to proxy the request to. For example:
```json
[
  {
    "url": "https://www.google.com"
  },
  {
    "url": "http://mycustodomain.com",
    "method": "POST",
    "payload": {
      "key1": "value1"
    }
  }
]
```
The endpoint returns
* 400 for a bad request (for example, missing "url" or being not a list)
* If succesful, for every url
```
{
    "status": "ok if response code is 2xx",
    "status_code": "the exact status code",
    "headers": "response headers"
}
```
* If failure, for every url
```
{
    "status": "error",
    "reason": "Python requests error class name"
}
```
**Example**
```
$ curl -d '[{"url":"https://www.google.com"},{"url":"http://httpbin.org/post","method":"POST","payload":{"key":"42"}}]' -H "Content-Type: application/json" -X POST localhost:8080/proxy
{
  "http://httpbin.org/post": {
    "headers": {
      "Access-Control-Allow-Credentials": "true",
      "Access-Control-Allow-Origin": "*",
      "Connection": "keep-alive",
      "Content-Length": "435",
      "Content-Type": "application/json",
      "Date": "Sat, 19 Aug 2017 23:39:35 GMT",
      "Server": "meinheld/0.6.1",
      "Via": "1.1 vegur",
      "X-Powered-By": "Flask",
      "X-Processed-Time": "0.00157999992371"
    },
    "status": "ok",
    "status_code": 200
  },
  "https://www.google.com": {
    "headers": {
      "Alt-Svc": "quic=\":443\"; ma=2592000; v=\"39,38,37,35\"",
      "Cache-Control": "private, max-age=0",
      "Content-Encoding": "gzip",
      "Content-Type": "text/html; charset=ISO-8859-1",
      "Date": "Sat, 19 Aug 2017 23:39:35 GMT",
      "Expires": "-1",
      "P3P": "CP=\"This is not a P3P policy! See https://www.google.com/support/accounts/answer/151657?hl=en for more info.\"",
      "Server": "gws",
      "Set-Cookie": "NID=110=gR5VUAdefT9VbTSdOHEaiP-_ryClfvAV3ovON-uOh7d59L8YsQjkQsbDwSNMwEl0JOj-7aXIQnbceL5WGZGnmbz9GFWFHsHPqRsCPaquyHIsboWMNkzhVr4Te2E6-D94; expires=Sun, 18-Feb-2018 23:39:35 GMT; path=/; domain=.google.co.uk; HttpOnly",
      "Transfer-Encoding": "chunked",
      "X-Frame-Options": "SAMEORIGIN",
      "X-XSS-Protection": "1; mode=block"
    },
    "status": "ok",
    "status_code": 200
  }
}
```