### PR TITLE
Add liveness and readiness endpoints instead of generic healthcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,11 @@ after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then
     echo "Building $TRAVIS_BRANCH image from commit $COMMIT";
     docker login -u $DOCKER_USER -p $DOCKER_PASS;
-    docker build -f Dockerfile -t $TRAVIS_REPO_SLUG:$COMMIT .;
-    docker tag $TRAVIS_REPO_SLUG:$COMMIT $TRAVIS_REPO_SLUG:latest;
+    docker build -f Dockerfile -t $TRAVIS_REPO_SLUG:latest .;
+    if [ ! -z "$TRAVIS_TAG"]; then
+    echo "Tagging image";
+    docker tag $TRAVIS_REPO_SLUG:$latest $TRAVIS_REPO_SLUG:$TRAVIS_TAG;
+    fi
     docker push $TRAVIS_REPO_SLUG;
     fi
 env:

--- a/README.md
+++ b/README.md
@@ -23,12 +23,18 @@ To override the default settings:
     * _returns_: a JSON with the `AF_INET` address family info for all the network interfaces.
 * `GET /network/<interface>`
     * _returns_: a JSON with the `AF_INET` address family info of the target interface or `404` if the network interface does not exist.
-* `GET /healthcheck`
-    * _returns_: the JSON `{"message": "infrabin is healthy"}` if healthy or the status code `503` if unhealthy.
-* `POST /healthcheck/pass`
-    * _returns_: `204` on success, resetting the `/healthcheck` endpoint to be healthy.
-* `POST /healthcheck/fail`
-    * _returns_: `204` on success, forcing the `/healthcheck` endpoint to be unhealthy.
+* `GET /healthcheck/liveness`
+    * _returns_: the JSON `{"message": "liveness probe healthy"}` if healthy or the status code `503` if unhealthy.
+* `POST /healthcheck/liveness/pass`
+    * _returns_: `204` on success, resetting the `/healthcheck/liveness` endpoint to be healthy.
+* `POST /healthcheck/liveness/fail`
+    * _returns_: `204` on success, forcing the `/healthcheck/liveness` endpoint to be unhealthy.
+* `GET /healthcheck/readiness`
+    * _returns_: the JSON `{"message": "readiness probe healthy"}` if healthy or the status code `503` if unhealthy.
+* `POST /healthcheck/readiness/pass`
+    * _returns_: `204` on success, resetting the `/healthcheck/readiness` endpoint to be healthy.
+* `POST /healthcheck/readiness/fail`
+    * _returns_: `204` on success, forcing the `/healthcheck/readiness` endpoint to be unhealthy.
 * `GET /env/<env_var>`
     * _returns_: the value of `env_var` or `404` if the environment variable does not exist.
 * `GET /aws/<metadata_endpoint>`

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,8 @@ See:
 https://packaging.python.org/en/latest/distributing.html
 https://github.com/pypa/sampleproject
 """
-
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
-
 
 setup(
     name='infrabin',
@@ -15,7 +13,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.2',
+    version='0.0.3',
 
     description='Like httpbin, but for infrastructure',
 

--- a/src/infrabin/app.py
+++ b/src/infrabin/app.py
@@ -13,7 +13,8 @@ from infrabin.helpers import status_code, gzipped
 app = Flask(__name__)
 cache = Cache(app, config={"CACHE_TYPE": "simple"})
 
-is_healthy = True
+liveness_healthy = True
+readiness_healthy = True
 AWS_METADATA_ENDPOINT = "http://169.254.169.254/latest/meta-data/"
 
 
@@ -52,26 +53,49 @@ def network(interface=None):
     return jsonify(data)
 
 
-@app.route("/healthcheck")
-def healthcheck():
-    global is_healthy
-    if is_healthy:
-        return jsonify({"message": "infrabin is healthy"})
+@app.route("/healthcheck/liveness")
+def healthcheck_liveness():
+    global liveness_healthy
+    if liveness_healthy:
+        return jsonify({"message": "liveness probe healthy"})
     else:
         return status_code(503)
 
 
-@app.route("/healthcheck/pass", methods=["POST"])
-def healthcheck_pass():
-    global is_healthy
-    is_healthy = True
+@app.route("/healthcheck/liveness/pass", methods=["POST"])
+def healthcheck_liveness_pass():
+    global liveness_healthy
+    liveness_healthy = True
     return status_code(204)
 
 
-@app.route("/healthcheck/fail", methods=["POST"])
-def healthcheck_fail():
-    global is_healthy
-    is_healthy = False
+@app.route("/healthcheck/liveness/fail", methods=["POST"])
+def healthcheck_liveness_fail():
+    global liveness_healthy
+    liveness_healthy = False
+    return status_code(204)
+
+
+@app.route("/healthcheck/readiness")
+def healthcheck_readiness():
+    global readiness_healthy
+    if readiness_healthy:
+        return jsonify({"message": "readiness probe healthy"})
+    else:
+        return status_code(503)
+
+
+@app.route("/healthcheck/readiness/pass", methods=["POST"])
+def healthcheck_readiness_pass():
+    global readiness_healthy
+    readiness_healthy = True
+    return status_code(204)
+
+
+@app.route("/healthcheck/readiness/fail", methods=["POST"])
+def healthcheck_readiness_fail():
+    global readiness_healthy
+    readiness_healthy = False
     return status_code(204)
 
 

--- a/tests/test_infrabin.py
+++ b/tests/test_infrabin.py
@@ -32,31 +32,58 @@ def test_main(client):
     assert data == {"message": "infrabin is running"}
 
 
-def test_healthcheck_pass(client):
-    response = client.get("/healthcheck")
+def test_healthcheck_liveness_pass(client):
+    response = client.get("/healthcheck/liveness")
     data = json.loads(response.data.decode("utf-8"))
     assert response.status_code == 200
-    assert data == {"message": "infrabin is healthy"}
+    assert data == {"message": "liveness probe healthy"}
 
 
-def test_healthcheck_fail(client):
-    post = client.post("/healthcheck/fail")
+def test_healthcheck_liveness_fail(client):
+    post = client.post("/healthcheck/liveness/fail")
     assert post.status_code == 204
-    get = client.get("/healthcheck")
+    get = client.get("/healthcheck/liveness")
     assert get.status_code == 503
 
 
-def test_healthcheck_switch(client):
-    post_fail = client.post("/healthcheck/fail")
+def test_healthcheck_liveness_switch(client):
+    post_fail = client.post("/healthcheck/liveness/fail")
     assert post_fail.status_code == 204
-    get_fail = client.get("/healthcheck")
+    get_fail = client.get("/healthcheck/liveness")
     assert get_fail.status_code == 503
-    post_pass = client.post("/healthcheck/pass")
+    post_pass = client.post("/healthcheck/liveness/pass")
     assert post_pass.status_code == 204
-    get_pass = client.get("/healthcheck")
+    get_pass = client.get("/healthcheck/liveness")
     get_pass_data = json.loads(get_pass.data.decode("utf-8"))
     assert get_pass.status_code == 200
-    assert get_pass_data == {"message": "infrabin is healthy"}
+    assert get_pass_data == {"message": "liveness probe healthy"}
+
+
+def test_healthcheck_readiness_pass(client):
+    response = client.get("/healthcheck/readiness")
+    data = json.loads(response.data.decode("utf-8"))
+    assert response.status_code == 200
+    assert data == {"message": "readiness probe healthy"}
+
+
+def test_healthcheck_readiness_fail(client):
+    post = client.post("/healthcheck/readiness/fail")
+    assert post.status_code == 204
+    get = client.get("/healthcheck/readiness")
+    assert get.status_code == 503
+
+
+def test_healthcheck_readiness_switch(client):
+    post_fail = client.post("/healthcheck/readiness/fail")
+    assert post_fail.status_code == 204
+    get_fail = client.get("/healthcheck/readiness")
+    assert get_fail.status_code == 503
+    post_pass = client.post("/healthcheck/readiness/pass")
+    assert post_pass.status_code == 204
+    get_pass = client.get("/healthcheck/readiness")
+    get_pass_data = json.loads(get_pass.data.decode("utf-8"))
+    assert get_pass.status_code == 200
+    assert get_pass_data == {"message": "readiness probe healthy"}
 
 
 def test_env_if_present(client):


### PR DESCRIPTION
Remove the generic `/healthcheck` endpoint to follow the k8s semantic of `liveness` and `readiness`. See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/