### PR TITLE
Support any method

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ To override the default settings:
     * _returns_: same as `GET /status` or `400` if the request is malformed.
 * `GET /gzip`
     * _returns_: the JSON `{"message": "this is gzip compressed"}` gzip compressed.
-* `GET /replay/<url>`
-    * _returns_: a JSON with the requested url.
+* `GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH /replay`
+    * _returns_: a JSON with the requested method (except for the `HEAD` method).
+* `GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH /replay/<anything>`
+    * _returns_: a JSON with the requested string as `replay` (except for the `HEAD` method) and method.
 * `POST /proxy`
     * _payload_: a JSON with a list of `url` (mandatory), `method` (optional) and `payload` (optional) to proxy.
     * _returns_: `400` if the request if malformed or a JSON with the a response for every request. If successful, the response contains `status: ok`, the `status_code` and the `headers`. If unsuccessful, the response contains `status: error` and the `reason`.

--- a/src/infrabin/app.py
+++ b/src/infrabin/app.py
@@ -16,6 +16,7 @@ cache = Cache(app, config={"CACHE_TYPE": "simple"})
 liveness_healthy = True
 readiness_healthy = True
 AWS_METADATA_ENDPOINT = "http://169.254.169.254/latest/meta-data/"
+ALL_METHODS = ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"]
 
 
 @app.route("/")
@@ -165,11 +166,14 @@ def gzip():
     return jsonify(response)
 
 
-@app.route("/replay/<path:url>")
-def replay(url):
+@app.route("/replay", methods=ALL_METHODS)
+@app.route("/replay/<path:anything>", methods=ALL_METHODS)
+def replay(anything=None):
     response = {
-        "replay": url
+        "method": request.method
     }
+    if anything:
+        response["replay"] = anything
     return jsonify(response)
 
 


### PR DESCRIPTION
Support any HTTP method in the `/reaply` and `/replay/<anything>` endpoints