### PR TITLE
Fix PEP8

### DIFF
--- a/tests/test_infrabin.py
+++ b/tests/test_infrabin.py
@@ -321,7 +321,7 @@ def test_mirror_json(client, method):
     )
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json"
-    if method is not "HEAD":
+    if method != "HEAD":
         data = json.loads(response.data.decode("utf-8"))
         assert data == payload
 


### PR DESCRIPTION
Fix https://travis-ci.org/maruina/infrabin/builds/554705085 where we fail the linting step because of 
```
tests/test_infrabin.py:324:8: F632 use ==/!= to compare str, bytes, and int literals
```